### PR TITLE
Change format of Clarity torqueBP values from hexadecimal to decimal

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -180,10 +180,10 @@ class CarInterface(CarInterfaceBase):
 
     elif candidate == CAR.HONDA_CLARITY:
       if eps_modified: # 2X mod
-        ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 0xA00, 0x2800], [0, 2560, 3840]]
+        ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 5760, 10240], [0, 2560, 3840]]
         ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.1]]
       elif eps_modified_3x: # 3X mod
-        ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 0xA00, 0x3C00], [0, 2560, 3840]]
+        ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 5760, 15360], [0, 2560, 3840]]
         ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.1575], [0.05175]]
       else:
         ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 2560], [0, 2560]]


### PR DESCRIPTION
Clarity torqueBP values were the only values in interface.py to be listed in hexadecimal. Values format changed to decimal. Evaluated values are unchanged.

"Kiril — 9/16/2021 2:27 PM
It would be so much easier if people just used integers for both instead of hex"

Updated opendbc/car/honda/interface.py